### PR TITLE
Fix IllegalArgumentException when sessionToken cookie is empty

### DIFF
--- a/src/main/java/org/dhatim/dropwizard/jwt/cookie/authentication/JwtCookieAuthRequestFilter.java
+++ b/src/main/java/org/dhatim/dropwizard/jwt/cookie/authentication/JwtCookieAuthRequestFilter.java
@@ -41,14 +41,16 @@ class JwtCookieAuthRequestFilter<P extends JwtCookiePrincipal> extends AuthFilte
         Cookie cookie = crc.getCookies().get(cookieName);
         if (null != cookie) {
             String accessToken = cookie.getValue();
-            try {
-                final Optional<P> subject = authenticator.authenticate(accessToken);
-                if (subject.isPresent()) {
-                    crc.setSecurityContext(new JwtCookieSecurityContext(subject.get(), crc.getSecurityContext().isSecure()));
-                    return;
+            if (accessToken != null && accessToken.length() > 0) {
+                try {
+                    final Optional<P> subject = authenticator.authenticate(accessToken);
+                    if (subject.isPresent()) {
+                        crc.setSecurityContext(new JwtCookieSecurityContext(subject.get(), crc.getSecurityContext().isSecure()));
+                        return;
+                    }
+                } catch (AuthenticationException e) {
+                    throw new InternalServerErrorException(e);
                 }
-            } catch (AuthenticationException e) {
-                throw new InternalServerErrorException(e);
             }
         }
         throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));


### PR DESCRIPTION
While testing my application I noticed strange IllegalArgumentExceptions after logging out and trying to access a protected resource afterwards. It turned out, that my REST client (ARC for Chrome) sent an empty sessionToken cookie instead of removing the cookie completely from the headers. Although switching to a different REST client fixed the issue already for me, I propose this small check for an empty access token to avoid the same error on other clients.


Stacktrace:
```
java.lang.IllegalArgumentException: JWT String argument cannot be null or empty.
! at io.jsonwebtoken.lang.Assert.hasText(Assert.java:135)
! at io.jsonwebtoken.impl.DefaultJwtParser.parse(DefaultJwtParser.java:479)
! at io.jsonwebtoken.impl.DefaultJwtParser.parseClaimsJws(DefaultJwtParser.java:541)
! at org.dhatim.dropwizard.jwt.cookie.authentication.JwtCookiePrincipalAuthenticator.authenticate(JwtCookiePrincipalAuthenticator.java:41)
! at org.dhatim.dropwizard.jwt.cookie.authentication.JwtCookiePrincipalAuthenticator.authenticate(JwtCookiePrincipalAuthenticator.java:28)
! at org.dhatim.dropwizard.jwt.cookie.authentication.JwtCookieAuthRequestFilter.filter(JwtCookieAuthRequestFilter.java:45)
! at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:132)
! at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:68)
! at org.glassfish.jersey.process.internal.Stages.process(Stages.java:197)
! at org.glassfish.jersey.server.ServerRuntime$2.run(ServerRuntime.java:318)
! at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
! at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
! at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
! at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
! at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
! at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:317)
! at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:305)
! at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:1154)
! at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:473)
! at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:427)
! at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:388)
! at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:341)
! at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:228)
! at io.dropwizard.jetty.NonblockingServletHolder.handle(NonblockingServletHolder.java:49)
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1689)
! at io.dropwizard.servlets.ThreadNameFilter.doFilter(ThreadNameFilter.java:34)
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1676)
! at io.dropwizard.jersey.filter.AllowedMethodsFilter.handle(AllowedMethodsFilter.java:50)
! at io.dropwizard.jersey.filter.AllowedMethodsFilter.doFilter(AllowedMethodsFilter.java:44)
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1676)
! at org.tuckey.web.filters.urlrewrite.RuleChain.handleRewrite(RuleChain.java:176)
! at org.tuckey.web.filters.urlrewrite.RuleChain.doRules(RuleChain.java:145)
! at org.tuckey.web.filters.urlrewrite.UrlRewriter.processRequest(UrlRewriter.java:92)
! at org.tuckey.web.filters.urlrewrite.UrlRewriteFilter.doFilter(UrlRewriteFilter.java:394)
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1676)
! at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:89)
! at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:120)
! at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:135)
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1676)
! at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:581)
! at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1174)
! at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:511)
! at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1106)
! at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:134)
! at com.codahale.metrics.jetty9.InstrumentedHandler.handle(InstrumentedHandler.java:240)
! at io.dropwizard.jetty.RoutingHandler.handle(RoutingHandler.java:51)
! at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:459)
! at io.dropwizard.jetty.BiDiGzipHandler.handle(BiDiGzipHandler.java:68)
! at org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:56)
! at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:169)
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:134)
! at org.eclipse.jetty.server.Server.handle(Server.java:524)
! at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:319)
! at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:253)
! at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:273)
! at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95)
! at org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:93)
! at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.executeProduceConsume(ExecuteProduceConsume.java:303)
! at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceConsume(ExecuteProduceConsume.java:148)
! at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:136)
! at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:671)
! at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:589)
! at java.lang.Thread.run(Thread.java:745)
```