### PR TITLE
 expose request & response filter for manual setup 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.dhatim</groupId>
         <artifactId>root-oss</artifactId>
-        <version>6.2.0</version>
+        <version>10.3.0</version>
     </parent>
     <groupId>org.dhatim</groupId>
     <artifactId>dropwizard-jwt-cookie-authentication</artifactId>

--- a/src/main/java/org/dhatim/dropwizard/jwt/cookie/authentication/DontRefreshSessionFilter.java
+++ b/src/main/java/org/dhatim/dropwizard/jwt/cookie/authentication/DontRefreshSessionFilter.java
@@ -20,13 +20,13 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 
 @DontRefreshSession
-class DontRefreshSessionFilter implements ContainerRequestFilter{
+public class DontRefreshSessionFilter implements ContainerRequestFilter{
 
     public static String DONT_REFRESH_SESSION_PROPERTY = "dontRefreshSession";
-    
+
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         requestContext.setProperty(DONT_REFRESH_SESSION_PROPERTY, Boolean.TRUE);
     }
-    
+
 }


### PR DESCRIPTION
Non-trivial setup such as [Chained Factories](http://www.dropwizard.io/1.3.1/docs/manual/auth.html#chained-factories) or [Multiple Principals and Authenticators](http://www.dropwizard.io/1.3.1/docs/manual/auth.html#multiple-principals-and-authenticators) require direct access to filters.