### PR TITLE
Make UnauthorizedHandler overridable

### DIFF
--- a/src/main/java/org/dhatim/dropwizard/jwt/cookie/authentication/JwtCookieAuthRequestFilter.java
+++ b/src/main/java/org/dhatim/dropwizard/jwt/cookie/authentication/JwtCookieAuthRequestFilter.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import javax.annotation.Priority;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Priorities;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Cookie;
 
@@ -54,7 +53,7 @@ class JwtCookieAuthRequestFilter<P extends JwtCookiePrincipal> extends AuthFilte
                 }
             }
         }
-        throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));
+        throw unauthorizedHandler.buildException(prefix, realm);
     }
 
     public static class Builder<P extends JwtCookiePrincipal> extends AuthFilterBuilder<String, P, JwtCookieAuthRequestFilter<P>> {


### PR DESCRIPTION
Two related changes here:
- Change from always throwing WebApplicationException when a user fails to authenticate to throwing the result of the buildException method on the unauthorized handler. This matches the pattern used in the built-in BasicCredentialAuthFilter and OAuthCredentialAuthFilter.

- Add a `withUnauthorizedHandler` method to the bundle to set your own UnauthorizedHandler. This gives you the ability to change the response and exception thrown when a user fails to authenticate. For example, you can redirect to a login page if you're building a browser application.

Fixes #69 